### PR TITLE
Subscriptions now return Subscription objects

### DIFF
--- a/DeftSharp.Windows.Input/Keyboard/KeyboardListener.cs
+++ b/DeftSharp.Windows.Input/Keyboard/KeyboardListener.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Windows.Input;
@@ -20,25 +20,26 @@ public sealed class KeyboardListener : InputListener<KeyboardSubscription>, IDis
         _keyboardInterceptor.UnhookRequested += OnInterceptorUnhookRequested;
     }
 
-    public void Subscribe(Key key, Action<Key> onClick,
+    public KeyboardSubscription Subscribe(Key key, Action<Key> onClick,
         TimeSpan? intervalOfClick = null, KeyboardEvent keyboardEvent = KeyboardEvent.KeyDown)
     {
-        var keyboardSubscription =
-            new KeyboardSubscription(key, onClick, intervalOfClick ?? TimeSpan.Zero, keyboardEvent);
-
-        InputSubscriptions.Add(keyboardSubscription);
+        var subscription = new KeyboardSubscription(key, onClick, intervalOfClick ?? TimeSpan.Zero, keyboardEvent);
+        
+        InputSubscriptions.Add(subscription);
+        return subscription;
     }
 
-    public void Subscribe(IEnumerable<Key> keys, Action<Key> onClick,
-        TimeSpan? intervalOfClick = null, KeyboardEvent keyboardEvent = KeyboardEvent.KeyDown)
+    public IEnumerable<KeyboardSubscription> Subscribe(IEnumerable<Key> keys, Action<Key> onClick,
+        TimeSpan? intervalOfClick = null, KeyboardEvent keyboardEvent = KeyboardEvent.KeyDown) =>
+        keys.Select(key => Subscribe(key, onClick, intervalOfClick, keyboardEvent));
+
+    public KeyboardSubscription SubscribeOnce(Key key, Action<Key> onClick, KeyboardEvent keyboardEvent = KeyboardEvent.KeyDown)
     {
-        foreach (var key in keys)
-            Subscribe(key, onClick, intervalOfClick, keyboardEvent);
+        var subscription = new KeyboardSubscription(key, onClick, keyboardEvent, true);
+        InputSubscriptions.Add(subscription);
+        return subscription;
     }
-
-    public void SubscribeOnce(Key key, Action<Key> onClick, KeyboardEvent keyboardEvent = KeyboardEvent.KeyDown) =>
-        InputSubscriptions.Add(new KeyboardSubscription(key, onClick, keyboardEvent, true));
-
+    
     public void Unsubscribe(Key key)
     {
         var subscriptions = InputSubscriptions.Where(e => e.Key.Equals(key)).ToArray();

--- a/DeftSharp.Windows.Input/Mouse/MouseListener.cs
+++ b/DeftSharp.Windows.Input/Mouse/MouseListener.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using DeftSharp.Windows.Input.InteropServices.Mouse;
 using DeftSharp.Windows.Input.Shared.Interceptors;
@@ -18,20 +18,20 @@ public sealed class MouseListener : InputListener<MouseSubscription>, IDisposabl
         _mouseInterceptor.UnhookRequested += OnInterceptorUnhookRequested;
     }
 
-    private bool OnInterceptorUnhookRequested() => !InputSubscriptions.Any();
-
     public Coordinates GetPosition() => _mouseInterceptor.GetPosition();
 
-    public void Subscribe(MouseEvent mouseEvent, Action onAction, TimeSpan? intervalOfClick = null)
+    public MouseSubscription Subscribe(MouseEvent mouseEvent, Action onAction, TimeSpan? intervalOfClick = null)
     {
         var subscription = new MouseSubscription(mouseEvent, onAction, intervalOfClick ?? TimeSpan.Zero);
         InputSubscriptions.Add(subscription);
+        return subscription;
     }
 
-    public void SubscribeOnce(MouseEvent mouseEvent, Action onAction)
+    public MouseSubscription SubscribeOnce(MouseEvent mouseEvent, Action onAction)
     {
         var subscription = new MouseSubscription(mouseEvent, onAction, true);
         InputSubscriptions.Add(subscription);
+        return subscription;
     }
 
     public void Unsubscribe(MouseEvent mouseEvent)
@@ -77,6 +77,8 @@ public sealed class MouseListener : InputListener<MouseSubscription>, IDisposabl
         _mouseInterceptor.Unhook();
         base.Unregister();
     }
+    
+    private bool OnInterceptorUnhookRequested() => !InputSubscriptions.Any();
 
     private void OnMouseInput(object? sender, MouseInputArgs e)
     {


### PR DESCRIPTION
Subscriptions now return Subscription objects with information:
```c#
var subscription = keyboardListener.Subscribe(Key.A, key =>
{
  
});

Console.WriteLine(subscription.Id);
```
This works with both KeyboardListener and MouseListener. Now it is possible to unsubscribe from the event by ID:

```c#
keyboardListener.Unsubscribe(subscription.Id);
```