### PR TITLE
added 'await' to test methods to fix always passing test bug

### DIFF
--- a/DeftSharp.Windows.Input.Tests/Keyboard/KeyboardBinderTests.cs
+++ b/DeftSharp.Windows.Input.Tests/Keyboard/KeyboardBinderTests.cs
@@ -5,11 +5,11 @@ public class KeyboardBinderTests
     private readonly ThreadRunner _threadRunner = new();
 
     [Fact]
-    public void KeyboardBinder_IsKeyBound()
+    public async void KeyboardBinder_IsKeyBound()
     {
         var keyboardBinder = new KeyboardBinder();
 
-        _threadRunner.Run(() =>
+        await _threadRunner.Run(() =>
         {
             keyboardBinder.Bind(Key.A, Key.B);
 
@@ -19,11 +19,11 @@ public class KeyboardBinderTests
     }
     
     [Fact]
-    public void KeyboardBinder_IsKeyBoundWhenBindingTheSameKey()
+    public async void KeyboardBinder_IsKeyBoundWhenBindingTheSameKey()
     {
         var keyboardBinder = new KeyboardBinder();
 
-        _threadRunner.Run(() =>
+        await _threadRunner.Run(() =>
         {
             keyboardBinder.Bind(Key.C, Key.C);
 
@@ -32,11 +32,11 @@ public class KeyboardBinderTests
     }
     
     [Fact]
-    public void KeyboardBinder_BindMultipleKeysAtOnce()
+    public async void KeyboardBinder_BindMultipleKeysAtOnce()
     {
         var keyboardBinder = new KeyboardBinder();
 
-        _threadRunner.Run(() =>
+        await _threadRunner.Run(() =>
         {
             var keys = new List<Key>
             {
@@ -57,11 +57,11 @@ public class KeyboardBinderTests
     }
     
     [Fact]
-    public void KeyboardBinder_BindEmptyKeyCollection()
+    public async void KeyboardBinder_BindEmptyKeyCollection()
     {
         var keyboardBinder = new KeyboardBinder();
 
-        _threadRunner.Run(() =>
+        await _threadRunner.Run(() =>
         {
             var keys = new List<Key>();
 
@@ -72,11 +72,11 @@ public class KeyboardBinderTests
     }
     
     [Fact]
-    public void KeyboardBinder_Unbind()
+    public async void KeyboardBinder_Unbind()
     {
         var keyboardBinder = new KeyboardBinder();
 
-        _threadRunner.Run(() =>
+        await _threadRunner.Run(() =>
         {
             keyboardBinder.Bind(Key.A, Key.B);
             Assert.True(keyboardBinder.IsKeyBounded(Key.A));
@@ -88,11 +88,11 @@ public class KeyboardBinderTests
     }
     
     [Fact]
-    public void KeyboardBinder_UnbindAll()
+    public async void KeyboardBinder_UnbindAll()
     {
         var keyboardBinder = new KeyboardBinder();
 
-        _threadRunner.Run(() =>
+        await _threadRunner.Run(() =>
         {
             var keys = new List<Key>
             {
@@ -112,11 +112,11 @@ public class KeyboardBinderTests
     }
     
     [Fact]
-    public void KeyboardBinder_UnbindKeyThatHasNotBeenBound()
+    public async void KeyboardBinder_UnbindKeyThatHasNotBeenBound()
     {
         var keyboardBinder = new KeyboardBinder();
 
-        _threadRunner.Run(() =>
+        await _threadRunner.Run(() =>
         {
             Assert.Empty(keyboardBinder.BoundedKeys);
                 

--- a/DeftSharp.Windows.Input.Tests/Keyboard/KeyboardListenerSubscribeTests.cs
+++ b/DeftSharp.Windows.Input.Tests/Keyboard/KeyboardListenerSubscribeTests.cs
@@ -5,11 +5,11 @@ public sealed class KeyboardListenerSubscribeTests
     private readonly ThreadRunner _threadRunner = new();
 
     [Fact]
-    public void KeyboardListener_Subscribe()
+    public async void KeyboardListener_Subscribe()
     {
         var listener = new KeyboardListener();
 
-        _threadRunner.Run(() =>
+        await _threadRunner.Run(() =>
         {
             listener.Subscribe(Key.A, _ => { });
 
@@ -21,11 +21,11 @@ public sealed class KeyboardListenerSubscribeTests
     }
 
     [Fact]
-    public void KeyboardListener_Subscribe3()
+    public async void KeyboardListener_Subscribe3()
     {
         var listener = new KeyboardListener();
 
-        _threadRunner.Run(() =>
+        await _threadRunner.Run(() =>
         {
             listener.Subscribe(Key.A, _ => { });
             listener.Subscribe(Key.A, _ => { });
@@ -39,11 +39,11 @@ public sealed class KeyboardListenerSubscribeTests
     }
 
     [Fact]
-    public void KeyboardListener_SubscribeMany()
+    public async void KeyboardListener_SubscribeMany()
     {
         var listener = new KeyboardListener();
 
-        _threadRunner.Run(() =>
+        await _threadRunner.Run(() =>
         {
             Key[] keys = { Key.A, Key.K, Key.A, Key.B };
             listener.Subscribe(keys, _ => { });
@@ -58,11 +58,11 @@ public sealed class KeyboardListenerSubscribeTests
     }
 
     [Fact]
-    public void KeyboardListener_Subscribe12()
+    public async void KeyboardListener_Subscribe12()
     {
         var listener = new KeyboardListener();
 
-        _threadRunner.Run(() =>
+        await _threadRunner.Run(() =>
         {
             Key[] keys = { Key.A, Key.K, Key.A, Key.B };
             listener.Subscribe(keys, _ => { });
@@ -77,11 +77,11 @@ public sealed class KeyboardListenerSubscribeTests
     }
 
     [Fact]
-    public void KeyboardListener_SubscribeOnce()
+    public async void KeyboardListener_SubscribeOnce()
     {
         var listener = new KeyboardListener();
 
-        _threadRunner.Run(() =>
+        await _threadRunner.Run(() =>
         {
             Key[] keys = { Key.A, Key.K, Key.A, Key.B };
             listener.SubscribeOnce(Key.C, _ => { });
@@ -96,11 +96,11 @@ public sealed class KeyboardListenerSubscribeTests
     }
 
     [Fact]
-    public void KeyboardListener_SubscribeBack()
+    public async void KeyboardListener_SubscribeBack()
     {
         var listener = new KeyboardListener();
 
-        _threadRunner.Run(() =>
+        await _threadRunner.Run(() =>
         {
             listener.Subscribe(Key.Back, _ => { });
             listener.Subscribe(Key.Back, _ => { });
@@ -116,11 +116,11 @@ public sealed class KeyboardListenerSubscribeTests
     }
 
     [Fact]
-    public void KeyboardListener_SubscribeWithDispose()
+    public async void KeyboardListener_SubscribeWithDispose()
     {
         var listener = new KeyboardListener();
 
-        _threadRunner.Run(() =>
+        await _threadRunner.Run(() =>
         {
             listener.Subscribe(Key.J, _ => { });
             listener.Dispose();
@@ -130,58 +130,58 @@ public sealed class KeyboardListenerSubscribeTests
     }
 
     [Fact]
-    public void KeyboardListener_SubscribeCombination()
+    public async void KeyboardListener_SubscribeCombination()
     {
         var listener = new KeyboardListener();
 
         Key[] combination = { Key.C, Key.D, };
-        _threadRunner.Run(() => listener.SubscribeCombination(combination, () => { }));
+        await _threadRunner.Run(() =>
+        {
+            listener.SubscribeCombination(combination, () => { });
 
-        Assert.True(listener.Combinations.All(x => x.Combination.SequenceEqual(combination.AsEnumerable<Key>())),
-            "In the listener, the subscribed combination is not found within the combinations.");
-        Assert.True(listener.IsListening, "Keyboard listener is not listening subscription events.");
-        Assert.Single(listener.Combinations);
+            Assert.True(listener.Combinations.All(x => x.Combination.SequenceEqual(combination.AsEnumerable<Key>())),
+                "In the listener, the subscribed combination is not found within the combinations.");
+            Assert.True(listener.IsListening, "Keyboard listener is not listening subscription events.");
+            Assert.Single(listener.Combinations);
+        });
     }
 
     [Fact]
-    public void KeyboardListener_SubscribeCombinationMany()
+    public async void KeyboardListener_SubscribeCombinationMany()
     {
         var listener = new KeyboardListener();
 
         Key[] combination = { Key.C, Key.D, };
-        _threadRunner.Run(() =>
+        await _threadRunner.Run(() =>
         {
             for (var i = 0; i < 10; i++)
                 listener.SubscribeCombination(combination, () => { });
+
+            Assert.True(listener.Combinations.All(x => x.Combination.SequenceEqual(combination.AsEnumerable())),
+                    "In the listener, the subscribed combination is not found within the combinations.");
+            Assert.True(listener.IsListening, "Keyboard listener is not listening subscription events.");
+            Assert.Equal(10, listener.Combinations.Count());
         });
-
-        Assert.True(listener.Combinations.All(x => x.Combination.SequenceEqual(combination.AsEnumerable())),
-            "In the listener, the subscribed combination is not found within the combinations.");
-
-        Assert.True(listener.IsListening, "Keyboard listener is not listening subscription events.");
-        Assert.Equal(10, listener.Combinations.Count());
     }
 
     [Fact]
-    public void KeyboardListener_SubscribeCombinationOnce()
+    public async void KeyboardListener_SubscribeCombinationOnce()
     {
         var listener = new KeyboardListener();
 
         Key[] combination = { Key.C, Key.D };
-        _threadRunner.Run(() =>
+        await _threadRunner.Run(() =>
         {
             for (var i = 0; i < 5; i++)
             {
                 listener.SubscribeCombinationOnce(combination, () => { });
                 listener.SubscribeCombination(combination, () => { });
             }
+            Assert.True(listener.Combinations.All(x => x.Combination.SequenceEqual(combination.AsEnumerable())),
+                    "In the listener, the subscribed combination is not found within the combinations.");
+            Assert.True(listener.IsListening, "Keyboard listener is not listening subscription events.");
+            Assert.Equal(10, listener.Combinations.Count());
+            Assert.Equal(5, listener.Combinations.Count(x => x.SingleUse));
         });
-
-        Assert.True(listener.Combinations.All(x => x.Combination.SequenceEqual(combination.AsEnumerable())),
-            "In the listener, the subscribed combination is not found within the combinations.");
-
-        Assert.True(listener.IsListening, "Keyboard listener is not listening subscription events.");
-        Assert.Equal(10, listener.Combinations.Count());
-        Assert.Equal(5, listener.Combinations.Count(x => x.SingleUse));
     }
 }

--- a/DeftSharp.Windows.Input.Tests/Keyboard/KeyboardListenerUnsubscribeTests.cs
+++ b/DeftSharp.Windows.Input.Tests/Keyboard/KeyboardListenerUnsubscribeTests.cs
@@ -4,10 +4,10 @@ public sealed class KeyboardListenerUnsubscribeTests
 {
     private readonly ThreadRunner _threadRunner = new();
 
-    private void RunListenerTest(Action<KeyboardListener> onTest)
+    private async void RunListenerTest(Action<KeyboardListener> onTest)
     {
         var keyboardListener = new KeyboardListener();
-        _threadRunner.Run(() => onTest(keyboardListener));
+        await _threadRunner.Run(() => onTest(keyboardListener));
 
         Assert.False(keyboardListener.IsListening,
             "The Unregister function is not called after unsubscribing from all events.");

--- a/DeftSharp.Windows.Input.Tests/Keyboard/KeyboardManipulatorTests.cs
+++ b/DeftSharp.Windows.Input.Tests/Keyboard/KeyboardManipulatorTests.cs
@@ -5,12 +5,12 @@ public class KeyboardManipulatorTests : IDisposable
     private readonly ThreadRunner _threadRunner = new();
 
     [Fact]
-    public void KeyboardManipulator_PreventBy2()
+    public async void KeyboardManipulator_PreventBy2()
     {
         var keyboardManipulator1 = new KeyboardManipulator();
         var keyboardManipulator2 = new KeyboardManipulator();
 
-        _threadRunner.Run(() =>
+        await _threadRunner.Run(() =>
         {
             keyboardManipulator1.Prevent(Key.A);
             keyboardManipulator2.Prevent(Key.A);
@@ -22,12 +22,12 @@ public class KeyboardManipulatorTests : IDisposable
     }
 
     [Fact]
-    public void KeyboardManipulator_PreventReleaseAll()
+    public async void KeyboardManipulator_PreventReleaseAll()
     {
         var keyboardManipulator1 = new KeyboardManipulator();
         var keyboardManipulator2 = new KeyboardManipulator();
 
-        _threadRunner.Run(() =>
+        await _threadRunner.Run(() =>
         {
             keyboardManipulator1.Prevent(Key.A);
             keyboardManipulator2.Prevent(Key.A);
@@ -41,13 +41,13 @@ public class KeyboardManipulatorTests : IDisposable
     }
 
     [Fact]
-    public void KeyboardManipulator_PreventBy3()
+    public async void KeyboardManipulator_PreventBy3()
     {
         var keyboardManipulator1 = new KeyboardManipulator();
         var keyboardManipulator2 = new KeyboardManipulator();
         var keyboardManipulator3 = new KeyboardManipulator();
 
-        _threadRunner.Run(() =>
+        await _threadRunner.Run(() =>
         {
             keyboardManipulator1.Prevent(Key.Q);
             keyboardManipulator2.Prevent(Key.W);
@@ -63,13 +63,13 @@ public class KeyboardManipulatorTests : IDisposable
     }
 
     [Fact]
-    public void KeyboardManipulator_PreventBy2ReleaseAll()
+    public async void KeyboardManipulator_PreventBy2ReleaseAll()
     {
         var keyboardManipulator1 = new KeyboardManipulator();
         var keyboardManipulator2 = new KeyboardManipulator();
         var keyboardManipulator3 = new KeyboardManipulator();
 
-        _threadRunner.Run(() =>
+        await _threadRunner.Run(() =>
         {
             keyboardManipulator1.Prevent(Key.Q);
             keyboardManipulator2.Prevent(Key.W);
@@ -82,9 +82,9 @@ public class KeyboardManipulatorTests : IDisposable
     }
 
     [Fact]
-    public void KeyboardManipulator_DisposeTest()
+    public async void KeyboardManipulator_DisposeTest()
     {
-        _threadRunner.Run(() =>
+        await _threadRunner.Run(() =>
         {
             using (var keyboardManipulator1 = new KeyboardManipulator())
             {

--- a/DeftSharp.Windows.Input.Tests/Mouse/MouseListenerSubscribeTests.cs
+++ b/DeftSharp.Windows.Input.Tests/Mouse/MouseListenerSubscribeTests.cs
@@ -5,11 +5,11 @@ public sealed class MouseListenerSubscribeTests
     private readonly ThreadRunner _threadRunner = new();
 
     [Fact]
-    public void MouseListener_SingleSubscribe()
+    public async void MouseListener_SingleSubscribe()
     {
         var listener = new MouseListener();
 
-        _threadRunner.Run(() =>
+        await _threadRunner.Run(() =>
         {
             listener.Subscribe(MouseEvent.Move, () => { });
 
@@ -21,11 +21,11 @@ public sealed class MouseListenerSubscribeTests
     }
 
     [Fact]
-    public void MouseListener_Identical3Subscriptions()
+    public async void MouseListener_Identical3Subscriptions()
     {
         var listener = new MouseListener();
 
-        _threadRunner.Run(() =>
+        await _threadRunner.Run(() =>
         {
             listener.Subscribe(MouseEvent.Move, () => { });
             listener.Subscribe(MouseEvent.Move, () => { });
@@ -39,11 +39,11 @@ public sealed class MouseListenerSubscribeTests
     }
 
     [Fact]
-    public void MouseListener_SubscribeOnce()
+    public async void MouseListener_SubscribeOnce()
     {
         var listener = new MouseListener();
 
-        _threadRunner.Run(() =>
+        await _threadRunner.Run(() =>
         {
             listener.SubscribeOnce(MouseEvent.LeftButtonDown, () => { });
 

--- a/DeftSharp.Windows.Input.Tests/Mouse/MouseListenerUnsubscribeTests.cs
+++ b/DeftSharp.Windows.Input.Tests/Mouse/MouseListenerUnsubscribeTests.cs
@@ -4,10 +4,10 @@ public sealed class MouseListenerUnsubscribeTests
 {
     private readonly ThreadRunner _threadRunner = new();
 
-    private void RunListenerTest(Action<MouseListener> onTest)
+    private async void RunListenerTest(Action<MouseListener> onTest)
     {
         var mouseListener = new MouseListener();
-        _threadRunner.Run(() => onTest(mouseListener));
+        await _threadRunner.Run(() => onTest(mouseListener));
 
         Assert.False(mouseListener.IsListening,
             "The Unregister function is not called after unsubscribing from all events.");

--- a/DeftSharp.Windows.Input.Tests/ThreadRunner.cs
+++ b/DeftSharp.Windows.Input.Tests/ThreadRunner.cs
@@ -5,16 +5,16 @@
 /// </summary>
 internal sealed class ThreadRunner
 {
-    public bool Run(Action onAction)
+    public async Task Run(Action onAction)
     {
         var threadFinished = new ManualResetEvent(false);
 
-        new Thread(() =>
+        await Task.Run(() =>
         {
             onAction();
             threadFinished.Set();
-        }).Start();
+        });
 
-        return threadFinished.WaitOne(3000);
+        threadFinished.WaitOne(3000);
     }
 }


### PR DESCRIPTION
#### I have found a weird bug in tests

### Bug description
Most of the tests that use a `ThreadRunner` class seem to always pass a test, regardless of asserted results.
It's probably a Thread issue.

### To Reproduce
* add `Assert.Fail()` to a test method or change the expected value to a false one
* Run tests
* Test passes, but it shouldn't

![image](https://github.com/Empiree/DeftSharp.Windows.Input/assets/156582923/8f123413-ba73-49a8-8354-d727ed53bd85)
![image](https://github.com/Empiree/DeftSharp.Windows.Input/assets/156582923/6e2d5c56-3c29-4d86-bd20-ca8d72d8574d)

**Additional context**
Changed the `ThreadRunner` class to return `Task` and changed methods that have shown the issue to async,
It is working fine now.

**My setup**
 - OS: Windows 10
 - VS: Microsoft Visual Studio Community 2022 (64-bit)