### PR TITLE
Created KeyboardManipulator tests for SetInterval, ResetInterval, and ResetIntervals

### DIFF
--- a/DeftSharp.Windows.Input.Tests/Keyboard/KeyboardManipulatorTests.cs
+++ b/DeftSharp.Windows.Input.Tests/Keyboard/KeyboardManipulatorTests.cs
@@ -103,6 +103,74 @@ public class KeyboardManipulatorTests : IDisposable
         });
     }
 
+    [Fact]
+    public async void KeyboardManipulator_SetInterval2()
+    {
+        TimeSpan interval = new TimeSpan(1000);
+        var keyboardManipulator1 = new KeyboardManipulator();
+        var keyboardManipulator2 = new KeyboardManipulator();
+
+        await Task.Run(() =>
+        {
+            keyboardManipulator1.SetInterval(Key.Q, interval);
+            keyboardManipulator2.SetInterval(Key.W, interval);
+
+
+            Assert.Equal(keyboardManipulator1.KeyPressIntervals.Count(), keyboardManipulator2.KeyPressIntervals.Count());
+
+            keyboardManipulator1.ResetInterval(Key.Q);
+            keyboardManipulator1.ResetInterval(Key.W);
+
+            Assert.Empty(keyboardManipulator1.KeyPressIntervals);
+        });
+    }
+
+    [Fact]
+    public async void KeyboardManipulator_SetInterval3()
+    {
+        TimeSpan interval = new TimeSpan(1000);
+        var keyboardManipulator1 = new KeyboardManipulator();
+        var keyboardManipulator2 = new KeyboardManipulator();
+        var keyboardManipulator3 = new KeyboardManipulator();
+
+        await Task.Run(() =>
+        {
+            keyboardManipulator1.SetInterval(Key.Q, interval);
+            keyboardManipulator2.SetInterval(Key.W, interval);
+            keyboardManipulator3.SetInterval(Key.E, interval);
+
+
+            Assert.Equal(keyboardManipulator1.KeyPressIntervals.Count(), keyboardManipulator2.KeyPressIntervals.Count());
+            Assert.Equal(keyboardManipulator2.KeyPressIntervals.Count(), keyboardManipulator3.KeyPressIntervals.Count());
+
+            keyboardManipulator1.ResetInterval();
+
+            Assert.Empty(keyboardManipulator1.KeyPressIntervals);
+        });
+    }
+
+    [Fact]
+    public async void KeyboardManipulator_SetInterval2ReleaseAll()
+    {
+        TimeSpan interval = new TimeSpan(1000);
+        var keyboardManipulator1 = new KeyboardManipulator();
+        var keyboardManipulator2 = new KeyboardManipulator();
+        var keyboardManipulator3 = new KeyboardManipulator();
+
+        await Task.Run(() =>
+        {
+            keyboardManipulator1.SetInterval(Key.Q, interval);
+            keyboardManipulator2.SetInterval(Key.W, interval);
+
+            Assert.Equal(keyboardManipulator1.KeyPressIntervals.Count(), keyboardManipulator2.KeyPressIntervals.Count());
+            Assert.Equal(keyboardManipulator2.KeyPressIntervals.Count(), keyboardManipulator3.KeyPressIntervals.Count());
+
+            keyboardManipulator3.ResetInterval();
+
+            Assert.Empty(keyboardManipulator1.KeyPressIntervals);
+        });
+    }
+
     public void Dispose()
     {
         var manipulator = new KeyboardManipulator();

--- a/DeftSharp.Windows.Input/Keyboard/Interceptors/KeyboardIntervalInterceptor.cs
+++ b/DeftSharp.Windows.Input/Keyboard/Interceptors/KeyboardIntervalInterceptor.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Linq;
 using System.Windows.Input;
 using DeftSharp.Windows.Input.Interceptors;
@@ -14,6 +15,8 @@ internal sealed class KeyboardIntervalInterceptor : KeyboardInterceptor
     public static KeyboardIntervalInterceptor Instance => LazyInstance.Value;
 
     private readonly ConcurrentDictionary<Key, KeyPressInterval> _keyPressIntervals;
+
+    public IEnumerable<Key> KeyPressIntervals => _keyPressIntervals.Keys;
 
     private KeyboardIntervalInterceptor()
         : base(InterceptorType.Prohibitive) =>

--- a/DeftSharp.Windows.Input/Keyboard/KeyboardManipulator.cs
+++ b/DeftSharp.Windows.Input/Keyboard/KeyboardManipulator.cs
@@ -19,6 +19,12 @@ public sealed class KeyboardManipulator : IKeyboardManipulator
     /// </summary>
     public IEnumerable<Key> LockedKeys => _manipulator.LockedKeys;
 
+
+    /// <summary>
+    /// Gets the key press intervals.
+    /// </summary>
+    public IEnumerable<Key> KeyPressIntervals => _intervalInterceptor.KeyPressIntervals;
+
     /// <summary>
     /// Event triggered when a key press event is prevented.
     /// </summary>


### PR DESCRIPTION
In order to allow for the KeyboardManipulator tests to access intervals, an enumerable key was created KeyPressIntervals in KeyboardManipulator.cs and KeyboardIntervalInterceptor.cs, allowing the KeyboardManipulator class access to the key press intervals from KeyboardIntervalInterceptor.cs. All of the 3 new tests have passed, with all 5 previous tests still passing as well

![Screenshot 2024-05-14 210816](https://github.com/Empiree/DeftSharp.Windows.Input/assets/27712363/3f336130-cd80-41e2-8927-4d818132968b)
